### PR TITLE
Exchange not supported ops.json with permissions.json

### DIFF
--- a/minecraft_launcher.sh
+++ b/minecraft_launcher.sh
@@ -7,12 +7,12 @@ work_dir="${base_dir}"/"${server}"
 mkdir -p "${work_dir}"
 touch "${work_dir}"/whitelist.json
 touch "${work_dir}"/server.properties
-touch "${work_dir}"/ops.json
+touch "${work_dir}"/permissions.json
 
 docker run -d -h ${server} --name=${server}\
  -v "${work_dir}/whitelist.json:/opt/minecraft/whitelist.json:z"\
  -v "${work_dir}/server.properties:/opt/minecraft/server.properties:z"\
- -v "${work_dir}/ops.json:/opt/minecraft2/ops.json:z"\
+ -v "${work_dir}/permissions.json:/opt/minecraft/permissions.json:z"\
  -v "${work_dir}/worlds:/opt/minecraft/worlds:z"\
  --network=host\
  imetzach/minecraft-bedrockserver


### PR DESCRIPTION
Minecraft Bedrock Server doesn't support ops.json
Operator privileges are granted via permissions.json. 
Also fixed the target folder's name for said file.